### PR TITLE
add check so gpt.js is only loaded once

### DIFF
--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -24,6 +24,9 @@
     // Default DFP jQuery selector
     var dfpSelector = '.adunit';
 
+    // Keep track of if we've already tried to load gpt.js before
+    var dfpIsLoaded = false;
+
     /**
      * Init function sets required params and loads Google's DFP script
      * @param  String id       The DFP account ID
@@ -284,6 +287,12 @@
      * blocker... if it does not load we execute a dummy script to replace the real DFP.
      */
     var dfpLoader = function () {
+
+        // make sure we don't load gpt.js multiple times
+        dfpIsLoaded = dfpIsLoaded || $('script[src*="googletagservices.com/tag/js/gpt.js"]').length;
+        if (dfpIsLoaded){
+            return;
+        }
 
         window.googletag = window.googletag || {};
         window.googletag.cmd = window.googletag.cmd || [];


### PR DESCRIPTION
This fixes an issue where repeated calls to .dfp would result in
multiple copies of the doubleclick javascript.

There's a $('script').length check. This doesn't just keep track of its own state because it's possible for gpt.js to get injected some external means.

Uses a kinda crappy selector, `src*=` because it could be http... it
could be https... and there could be GET parameters. But it's only run
once. After the first time, dfpIsLoaded becomes truthy and the selector
isn't evaluated again.

The script blocking detection appears to still work.
