### PR TITLE
getDimensions performance and style tweaks

### DIFF
--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -274,15 +274,15 @@
             $adUnit = $(adUnit),
             dimensionsData = $adUnit.data('dimensions');
 
-        // check if data-dimensions are specified if not use the dimensions of the ad unit div
+        // Check if data-dimensions are specified. If they aren't, use the dimensions of the ad unit div.
         if (typeof dimensionsData !== 'undefined') {
 
-            var dimension_groups = dimensionsData.split(',');
+            var dimensionGroups = dimensionsData.split(',');
 
-            $.each(dimension_groups, function (k, v) {
+            $.each(dimensionGroups, function (k, v) {
 
-                var dimension_set = v.split('x');
-                dimensions.push([parseInt(dimension_set[0], 10), parseInt(dimension_set[1], 10)]);
+                var dimensionSet = v.split('x');
+                dimensions.push([parseInt(dimensionSet[0], 10), parseInt(dimensionSet[1], 10)]);
 
             });
 


### PR DESCRIPTION
Caching the jquery object and .data() might get you 1% better performance. It's not much, but it's worth it. Here's a simple jsperf (that doesn't really apply here since we're passing in a dom element and not a selector but is a good illustration anyways): http://jsperf.com/jquery-re-selecting-vs-caching-selections 

All the other variables are camelCased, so the dimension_lalala variables kind of stuck out too.
