### PR TITLE
fix $(selector).dfp() did not return a jquery collection, not chainable.

### DIFF
--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -420,6 +420,8 @@
 
         init(id, selector, options);
 
+        return this;
+
     };
 
 })(window.jQuery, window);


### PR DESCRIPTION
I'm not sure what `$.dfp(...)` should return, so to make the diff smaller, I applied it to both ways of calling `.dfp(...)`. This PR makes it so you can do `console.log($('div.adunit').dfp(...))`. Previously, if you did that you would get `undefined`.
