### PR TITLE
Add ability to monkey patch window.googletag

### DIFF
--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -74,6 +74,13 @@
         // Merge options objects
         dfpOptions = $.extend(dfpOptions, options);
 
+        // If a custom googletag is specified, use it.
+        if (dfpOptions.googletag) {
+            window.googletag.cmd.push(function () {
+                $.extend(window.googletag, dfpOptions.googletag);
+            });
+        }
+
         // Loops through on page Ad units and gets ads for them.
         $(dfpSelector).each(function () {
 


### PR DESCRIPTION
So far, I've only used it to override googletag.display.
Useful for ads that aren't in doubleclick yet, for debugging css, and
creating live mocks.

I'm sure there are other potential uses.
### Example

For example, this is the code I'm using:

```
dfpOptions.googletag = {
  display: function (id) {
    var $elem = $('#' + id),
        dimBits = $elem.attr('data-dimensions').split('x'),
        name = $elem.attr('data-adunit');
    console.log('display', id, dimBits);
    $('<div class="adunit-debug"/>')
        .css({
          background: 'deeppink',
          border: 0,
          color: 'black',
          fontSize: '0.9em',
          lineHeight: dimBits[1] + 'px',
          margin: 0,
          overflow: 'hidden',
          padding: 0,
          textAlign: 'center',
          textOverflow: 'ellipses'
        })
        .text(name)
        .width(dimBits[0]).height(dimBits[1])
        .appendTo($elem);
    $elem.addClass('display-block');
  }
};
```

To render alternate ads that look like this:
![screen shot 2013-04-29 at 8 25 51 pm](https://f.cloud.github.com/assets/189908/442057/40b12532-b135-11e2-94fc-45d6754a667a.png)
