### PR TITLE
IE7-8 trim bug fixed.

### DIFF
--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -160,9 +160,9 @@
                     var exclusionsGroup = exclusions.split(',');
                     var valueTrimmed;
                     $.each(exclusionsGroup, function (k, v) {
-                        valueTrimmed = v.trim();
+                        valueTrimmed = $.trim(v);
                         if (valueTrimmed.length > 0) {
-                            googleAdUnit.setCategoryExclusion(v.trim());
+                            googleAdUnit.setCategoryExclusion(valueTrimmed);
                         }
                     });
                 }
@@ -219,9 +219,9 @@
                 var exclusionsGroup = dfpOptions.setCategoryExclusion.split(',');
                 var valueTrimmed;
                 $.each(exclusionsGroup, function (k, v) {
-                    valueTrimmed = v.trim();
+                    valueTrimmed = $.trim(v);
                     if (valueTrimmed.length > 0) {
-                        window.googletag.pubads().setCategoryExclusion(v.trim());
+                        window.googletag.pubads().setCategoryExclusion(valueTrimmed);
                     }
                 });
             }

--- a/tests/spec/adUnitSpec.js
+++ b/tests/spec/adUnitSpec.js
@@ -3,8 +3,8 @@ describe('Ad units', function () {
     beforeEach(function () {
         $('.adunit').remove();
         $('script[src*="googletagservices.com/tag/js/gpt.js"]').remove();
-        window.googletag = null;
-        delete window.googletag;
+        window.googletag = undefined;
+        
     });
 
     it("Auto generate an ID for the ad unit if no ID provided", function () {

--- a/tests/spec/categoryExclusionSpec.js
+++ b/tests/spec/categoryExclusionSpec.js
@@ -3,8 +3,7 @@ describe("Category Exclusion", function () {
     beforeEach(function () {
         $('.adunit').remove();
         $('script[src*="googletagservices.com/tag/js/gpt.js"]').remove();
-        window.googletag = null;
-        delete window.googletag;
+        window.googletag = undefined;
     });
 
     it("Gets called correctly (ad unit)", function () {

--- a/tests/spec/loadingPhaseSpec.js
+++ b/tests/spec/loadingPhaseSpec.js
@@ -3,8 +3,7 @@ describe('Loading Phase', function () {
     beforeEach(function () {
         $('.adunit').remove();
         $('script[src*="googletagservices.com/tag/js/gpt.js"]').remove();
-        window.googletag = null;
-        delete window.googletag;
+        window.googletag = undefined;
     });
 
     it('Script Appended', function () {


### PR DESCRIPTION
I did some tests Friday and I noticed that native 'trim' function is not supported in IE7-IE8. To fix the problem I used jquery 'trim' instead of the native 'trim'. 

I removed also the delete 'window.googletag' because the unit tests are failing in IE7-IE8.  If you're curious there is an article explaning why at this address: http://perfectionkills.com/understanding-delete/#misconceptions.
