### PR TITLE
Fix broken tests of DFP Script Loaded

### DIFF
--- a/tests/spec/loadingPhaseSpec.js
+++ b/tests/spec/loadingPhaseSpec.js
@@ -44,7 +44,7 @@ describe('Loading Phase', function () {
         }, "getVersion function to exist", 5000);
 
         runs(function () {
-            expect(window.googletag.getVersion()).toEqual('23');
+            expect(window.googletag.getVersion()).toBeGreaterThan('23');
         });
 
     });


### PR DESCRIPTION
Use "toBeGreaterThan" should avoid broken tests with new versions of DFP tag.
