### PR TITLE
adding code to allow for responsive size mapping & refresh

### DIFF
--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -215,6 +215,10 @@
                 // Store googleAdUnit reference
                 $adUnit.data(storeAs, googleAdUnit);
 
+                // Allow altering of the ad slot before ad load
+                if (typeof dfpOptions.beforeEachAdLoaded === 'function') {
+                    dfpOptions.beforeEachAdLoaded.call(this, $adUnit);
+                }
             });
 
         });
@@ -530,6 +534,36 @@
         init(id, selector, options);
 
         return this;
+
+    };
+
+    /**
+     * Refresh all created ads
+     */
+    $.dfpRefresh = $.fn.dfpRefresh = function() {
+
+        if (typeof $adCollection == 'undefined') {
+            return;
+        }
+
+        //Get all ad slot data
+        var slots = [];
+        $adCollection.each(function() {
+            // Allow altering of the ad slot before ad load
+            if (typeof dfpOptions.beforeEachAdLoaded === 'function') {
+                dfpOptions.beforeEachAdLoaded.call(window.googletag.cmd, $(this));
+            }
+
+            var $adUnitData = $(this).data(storeAs);
+            if ($adUnitData) {
+                slots[slots.length] = $adUnitData;
+            }
+        });
+
+        //Refresh the ad slots
+        window.googletag.cmd.push(function() {
+            window.googletag.pubads().refresh(slots);
+        });
 
     };
 


### PR DESCRIPTION
Where I work, we have found this project very helpful & reliable. Recently responsive ads were added as a requirement for one of our projects. To accomplish this, I needed to patch the code so size mapping could be passed to each ad slot before load. We found the mapping works before init & after refresh as expected.
Which brings me to the $.dfpRefresh(); method. This obviously can be called at any time and can be used for more than just responsive ads. Hope this code is found to be useful. Cheers! -Daniel
