### PR TITLE
pass the slotRenderedEvent to afterEachAdLoaded

### DIFF
--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -259,7 +259,7 @@
 
                 // Excute afterEachAdLoaded callback if provided
                 if (typeof dfpOptions.afterEachAdLoaded === 'function') {
-                    dfpOptions.afterEachAdLoaded.call(this, $adUnit);
+                    dfpOptions.afterEachAdLoaded.call(this, $adUnit, event);
                 }
 
                 // Excute afterAllAdsLoaded callback if provided


### PR DESCRIPTION
I'm using jquery.dfp.js and davidjbradshaw/iframe-resizer. In order for the iframe-resizer to work accurately the iframe widths or heights have to be fluid if you want the iframe to expand horizontally or vertically, respectively.  Given there are cases where there may be more than one configured dimension on the ad unit, it is amazingly helpful to have the rendered ad `size` as passed back from the `slotRenderEnded` event.  In this way, I can resize the containing div to the base rendered ad size then set the iframe to have a fluid dimension to allow for expandability.
