### PR TITLE
Added dummy implementation of enableServices method to silence gpt warning message in various tests

### DIFF
--- a/tests/spec/adUnitSpec.js
+++ b/tests/spec/adUnitSpec.js
@@ -10,9 +10,15 @@ describe('Ad units', function () {
 
     it("Auto generate an ID for the ad unit if no ID provided", function () {
 
+        var dummyTag = {};
+        dummyTag.enableServices = function() {};
+
         runs(function () {
             $('body').append('<div class="adunit" data-adunit="Leader"></div>');
-            $.dfp({dfpID: 'xxxxxxx'});
+            $.dfp({
+                dfpID: 'xxxxxxx',
+                googletag: dummyTag
+            });
         }, "Kick off loader");
 
         waitsFor(function () {
@@ -31,9 +37,15 @@ describe('Ad units', function () {
 
     it("Google ad unit object get attached to the ad unit container", function () {
 
+        var dummyTag = {};
+        dummyTag.enableServices = function() {};
+
         runs(function () {
             $('body').append('<div class="adunit" data-adunit="Leader"></div>');
-            $.dfp({dfpID: 'xxxxxxx'});
+            $.dfp({
+                dfpID: 'xxxxxxx',
+                googletag: dummyTag
+            });
         }, "Kick off loader");
 
         waitsFor(function () {
@@ -53,9 +65,16 @@ describe('Ad units', function () {
     it("Google ad unit object get attached to the ad unit container (with namespace)", function () {
         var namespace = 'my-long-namespace';
 
+        var dummyTag = {};
+        dummyTag.enableServices = function() {};
+
         runs(function () {
             $('body').append('<div class="adunit"></div>');
-            $.dfp({dfpID: 'xxxxxxx', namespace: namespace});
+            $.dfp({
+                dfpID: 'xxxxxxx',
+                googletag: dummyTag,
+                namespace: namespace
+            });
         }, "Kick off loader");
 
         waitsFor(function () {

--- a/tests/spec/callBacksSpec.js
+++ b/tests/spec/callBacksSpec.js
@@ -58,6 +58,7 @@ describe("Callbacks", function () {
         spyOn(mock, "afterEachAdLoaded").andCallThrough();
 
         var dummyTag = {};
+        dummyTag.enableServices = function() {};
         dummyTag.display = function () {
             mock.afterEachAdLoaded();
         };
@@ -157,6 +158,7 @@ describe("Callbacks", function () {
         spyOn(mock, "afterAllAdsLoaded").andCallThrough();
 
         var dummyTag = {};
+        dummyTag.enableServices = function() {};
         dummyTag.display = function () {
             mock.afterAllAdsLoaded();
         };
@@ -251,10 +253,14 @@ describe("Callbacks", function () {
 
     it("Alter the ad unit name using callback", function () {
 
+      var dummyTag = {};
+      dummyTag.enableServices = function() {};
+
       runs(function () {
         $('body').append('<div class="adunit" data-adunit="Bike" id="leader-123" data-model="BMX"></div>');
         $.dfp({
           dfpID: 'xxxxxxx',
+          googletag: dummyTag,
           alterAdUnitName: function(adUnitName,adUnit) {
             return "PREFIX_" + $(adUnit).data('model') + "_" + adUnitName + "_SUFFIX";
           }

--- a/tests/spec/categoryExclusionSpec.js
+++ b/tests/spec/categoryExclusionSpec.js
@@ -16,6 +16,7 @@ describe("Category Exclusion", function () {
         spyOn(mockAdunit, "setCategoryExclusion").andCallThrough();
 
         var dummyTag = {};
+        dummyTag.enableServices = function() {};
         dummyTag.defineSlot = function () {
             return {
                 addService: function () {
@@ -58,6 +59,7 @@ describe("Category Exclusion", function () {
         spyOn(mockAdunit, "setCategoryExclusion").andCallThrough();
 
         var dummyTag = {};
+        dummyTag.enableServices = function() {};
         dummyTag.defineSlot = function () {
             return {
                 addService: function () {
@@ -99,6 +101,7 @@ describe("Category Exclusion", function () {
         spyOn(mockAdunit, "setCategoryExclusion").andCallThrough();
 
         var dummyTag = {};
+        dummyTag.enableServices = function() {};
         dummyTag.defineSlot = function () {
             return {
                 addService: function () {
@@ -138,6 +141,7 @@ describe("Category Exclusion", function () {
         };
 
         var dummyTag = {};
+        dummyTag.enableServices = function() {};
         dummyTag.pubads = function () {
             return {
                 enableSingleRequest: function () {},
@@ -180,6 +184,7 @@ describe("Category Exclusion", function () {
         };
 
         var dummyTag = {};
+        dummyTag.enableServices = function() {};
         dummyTag.pubads = function () {
             return {
                 enableSingleRequest: function () {},
@@ -220,6 +225,7 @@ describe("Category Exclusion", function () {
         };
 
         var dummyTag = {};
+        dummyTag.enableServices = function() {};
         dummyTag.pubads = function () {
             return {
                 enableSingleRequest: function () {},

--- a/tests/spec/loadingPhaseSpec.js
+++ b/tests/spec/loadingPhaseSpec.js
@@ -10,8 +10,14 @@ describe('Loading Phase', function () {
 
     it('Script Appended', function () {
 
+        var dummyTag = {};
+        dummyTag.enableServices = function() {};
+
         runs(function () {
-            $.dfp({dfpID: 'xxxxxxx'});
+            $.dfp({
+                dfpID: 'xxxxxxx',
+                googletag: dummyTag
+            });
         }, "Kick off loader");
 
         waitsFor(function () {
@@ -20,7 +26,7 @@ describe('Loading Phase', function () {
             } else {
                 return false;
             }
-        }, "getVersion function to exist", 5000);
+        }, "getVersion function to exist", 1000);
 
         runs(function () {
             expect($('script[src*="googletagservices.com/tag/js/gpt.js"]').length).toEqual(1);
@@ -30,8 +36,14 @@ describe('Loading Phase', function () {
 
     it('DFP Script Loaded', function () {
 
+        var dummyTag = {};
+        dummyTag.enableServices = function() {};
+
         runs(function () {
-            $.dfp({dfpID: 'xxxxxxx'});
+            $.dfp({
+                dfpID: 'xxxxxxx',
+                googletag: dummyTag
+            });
         }, "Kick off loader");
 
         waitsFor(function () {

--- a/tests/spec/sizeMappingSpec.js
+++ b/tests/spec/sizeMappingSpec.js
@@ -16,6 +16,7 @@ describe("SizeMapping", function () {
         spyOn(mockAdunit, "defineSizeMapping").andCallThrough();
 
         var dummyTag = {};
+        dummyTag.enableServices = function() {};
         dummyTag.defineSlot = function () {
             return {
                 addService: function () {
@@ -63,6 +64,7 @@ describe("SizeMapping", function () {
         spyOn(mockAdunit, "defineSizeMapping").andCallThrough();
 
         var dummyTag = {};
+        dummyTag.enableServices = function() {};
         dummyTag.defineSlot = function () {
             return {
                 addService: function () {


### PR DESCRIPTION
Warning message:

    >> TypeError: 'undefined' is not an object (evaluating 'P["#7#"]') at
    >> http:\partner.googleadservices.com\gpt\pubads_impl_58.js:78
    >> http:\partner.googleadservices.com\gpt\pubads_impl_58.js:171