### PR TITLE
Add support to detect ghostery and/or adblock-plus

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -274,6 +274,15 @@ This script provides two callbacks which you can use to make working with DFP a 
         </td>
         <td>This is called before each ad unit has started rendering.</td>
     </tr>
+    <tr>
+        <td>afterAdBlocked(adUnit)</td>
+        <td>
+            <ul>
+                <li>adUnit - jQuery Object - the jQuery object</li>
+            </ul>
+        </td>
+        <td>This is called after each AdUnit has been blocked.</td>
+    </tr>   
 </table>
 
 Please see the [example-bootstrap.js](https://github.com/coop182/jquery.dfp.js/blob/master/example-bootstrap.js) file for an example of how to use these.

--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -56,7 +56,7 @@
          * @param  Object options  Custom options to apply
          */
         init = function (id, selector, options) {
-            var dfpOptions, $adCollection;
+            var $adCollection;
 
             // Reset counters on each call
             count = 0;
@@ -69,17 +69,17 @@
              * @returns {boolean}
              */
             dfpScript.shouldCheckForAdBlockers = function(){
-                return dfpOptions ? typeof dfpOptions.afterAdBlocked === 'function' : false;
+                return options ? typeof options.afterAdBlocked === 'function' : false;
             };
 
             // explicitly wait for loader to be completed, otherwise the googletag might not be available
             dfpLoader(options, $adCollection).then(function(){
-                dfpOptions = setOptions(options);
+                options = setOptions(options);
                 dfpScript.dfpOptions = options;
 
                 $(function () {
-                    createAds(dfpOptions, $adCollection);
-                    displayAds(dfpOptions, $adCollection);
+                    createAds(options, $adCollection);
+                    displayAds(options, $adCollection);
                 });
             });
 

--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -336,7 +336,7 @@
                         var slots = pubadsService.getSlots ? pubadsService.getSlots() : [];
                         if (slots.length > 0) {
                             $.get(slots[0].getContentUrl()).always(function (r) {
-                                if (r.statusText === 'error') {
+                                if (r.status !== 200) {
                                     $.each(slots, function () {
                                         var $adUnit = $('#' + this.getSlotId().getDomId());
                                         dfpOptions.afterAdBlocked.call(dfpScript, $adUnit, this);

--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -496,7 +496,7 @@
             // make sure we don't load gpt.js multiple times
             dfpIsLoaded = dfpIsLoaded || $('script[src*="googletagservices.com/tag/js/gpt.js"]').length;
             if (dfpIsLoaded) {
-                return;
+                return $.Deferred().resolve();
             }
 
             var loaded = $.Deferred();

--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -457,8 +457,11 @@
          * Call the google DFP script - there is a little bit of error detection in here to detect
          * if the dfp script has failed to load either through an error or it being blocked by an ad
          * blocker... if it does not load we execute a dummy script to replace the real DFP.
+         *
+         * @param {Object} options
+         * @param {Array} $adCollection
          */
-        dfpLoader = function () {
+        dfpLoader = function (options, $adCollection) {
 
             // make sure we don't load gpt.js multiple times
             dfpIsLoaded = dfpIsLoaded || $('script[src*="googletagservices.com/tag/js/gpt.js"]').length;

--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -355,6 +355,12 @@
                     $adUnitData = $adUnit.data(storeAs),
                     googletag = window.googletag;
 
+                if (googletag._adBlocked_) {
+                    if (typeof dfpOptions.afterAdBlocked === 'function') {
+                        dfpOptions.afterAdBlocked.call(dfpScript, $adUnit);
+                    }
+                }
+
                 if (dfpOptions.refreshExisting && $adUnitData && $adUnit.hasClass('display-block')) {
 
                     googletag.cmd.push(function () { googletag.pubads().refresh([$adUnitData]); });
@@ -484,6 +490,7 @@
             gads.onload = function() {
                 // this will work with ghostery:
                 if (!googletag._loadStarted_) {
+                    googletag._adBlocked_ = true;
                     $.each($adCollection, function () {
                         if (typeof options.afterAdBlocked === 'function') {
                             options.afterAdBlocked.call(dfpScript, $(this));

--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -64,7 +64,7 @@
             dfpID = id;
             $adCollection = $(selector);
 
-            dfpLoader();
+            dfpLoader(options);
             dfpOptions = setOptions(options);
 
             $(function () {
@@ -435,8 +435,10 @@
          * Call the google DFP script - there is a little bit of error detection in here to detect
          * if the dfp script has failed to load either through an error or it being blocked by an ad
          * blocker... if it does not load we execute a dummy script to replace the real DFP.
+         *
+         * @param {Object} options
          */
-        dfpLoader = function () {
+        dfpLoader = function (options) {
 
             // make sure we don't load gpt.js multiple times
             dfpIsLoaded = dfpIsLoaded || $('script[src*="googletagservices.com/tag/js/gpt.js"]').length;
@@ -453,7 +455,7 @@
 
             // Adblock blocks the load of Ad scripts... so we check for that
             gads.onerror = function () {
-                dfpBlocked();
+                dfpBlocked(options);
             };
 
             var useSSL = 'https:' === document.location.protocol;
@@ -464,7 +466,7 @@
 
             // Adblock plus seems to hide blocked scripts... so we check for that
             if (gads.style.display === 'none') {
-                dfpBlocked();
+                dfpBlocked(options);
             }
 
         },
@@ -475,8 +477,10 @@
          * regardless of whether DFP is actually loaded or not... it is basically only useful for situations
          * where you are laying DFP over existing content and need to init things like slide shows after the loading
          * is completed.
+         *
+         * @param {Object} options
          */
-        dfpBlocked = function () {
+        dfpBlocked = function (options) {
             var googletag = window.googletag;
 
             // Get the stored dfp commands
@@ -491,6 +495,11 @@
                         renderEnded: function () { },
                         addService: function () { return this; }
                     };
+
+                    if (typeof options.afterEachAdBlocked === 'function') {
+                        options.afterEachAdBlocked.call(this, name, dimensions, id);
+                    }
+
                     return googletag.ads[id];
                 };
 


### PR DESCRIPTION
This pull requests will add support to detect current versions of adblock-plus and ghostery.
There will be a new event available `afterAdBlocked`. It's called for each ad separately.

I successfully tested it with adblock plus in chrome/firefox and ghostery. The `dfpBlocked` Method is not called because the load of the base ad script is successful in current implementations.