### PR TITLE
Enable https by default

### DIFF
--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -369,7 +369,7 @@
             // Check if google adLoader can be loaded, this will work with AdBlock
             if(dfpScript.shouldCheckForAdBlockers() && !googletag._adBlocked_) {
                 if (googletag.getVersion) {
-                    var script = '//partner.googleadservices.com/gpt/pubads_impl_' +
+                    var script = 'https://partner.googleadservices.com/gpt/pubads_impl_' +
                         googletag.getVersion() + '.js';
                     $.getScript(script).always(function (r) {
                         if (r && r.statusText === 'error') {
@@ -543,9 +543,7 @@
                 loaded.resolve();
             };
 
-            var useSSL = 'https:' === document.location.protocol;
-            gads.src = (useSSL ? 'https:' : 'http:') +
-            '//www.googletagservices.com/tag/js/gpt.js';
+            gads.src = 'https://www.googletagservices.com/tag/js/gpt.js';
             var node = document.getElementsByTagName('script')[0];
             node.parentNode.insertBefore(gads, node);
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "2.4.2",
     "devDependencies": {
         "grunt": "~0.4",
-        "grunt-contrib-jasmine": "^0.8.2",
+        "grunt-contrib-jasmine": "^1.0.3",
         "grunt-contrib-jshint": "^0.11.1",
         "grunt-contrib-uglify": "^0.8.0"
     },


### PR DESCRIPTION
Hi @coop182 ,

Thanks a lot for this library. Great work. 

In my deploy scenario I run your code inside a `<iframe></iframe>`, and I hit https://bugs.webkit.org/show_bug.cgi?id=145692, which means that jquery.dfp tries to access `about://partner.googleadservices.com/gpt/pubads_impl_94.js`.

The solution that preserves the current behavior involves looping over `parent.location.protocol` until `about` is gone, or simply doing `top.location.protocol`. However, I considered the option of doing simply using https, and that is what is in the current code. This will be a problem for 3rd party creatives that serve over plain http, but I don't really know if this matters nowadays.

If you would prefer a different solution, by either looping over `parent.location.protocol`, or exposing this is a library flag, I will be happy to update the pull request.

I have opportunistically upgraded grunt-contrib-jasmine so tests stop hanging due to https://github.com/gruntjs/grunt-contrib-jasmine/issues/193.