### PR TITLE
Fixing #141, prevent listener to be called more then once, fixed tests

### DIFF
--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -303,37 +303,40 @@
                     pubadsService.setCentering(true);
                 }
 
-                // Setup event listener to listen for renderEnded event and fire callbacks.
-                pubadsService.addEventListener('slotRenderEnded', function (event) {
+                if(!googletag.__dfp_event__) {
+                    // Setup event listener to listen for renderEnded event and fire callbacks.
+                    pubadsService.addEventListener('slotRenderEnded', function (event) {
 
-                    rendered++;
+                        rendered++;
 
-                    var $adUnit = $('#' + event.slot.getSlotId().getDomId());
+                        var $adUnit = $('#' + event.slot.getSlotId().getDomId());
 
-                    var display = event.isEmpty ? 'none' : 'block';
+                        var display = event.isEmpty ? 'none' : 'block';
 
-                    // if the div has been collapsed but there was existing content expand the
-                    // div and reinsert the existing content.
-                    var $existingContent = $adUnit.data('existingContent');
-                    if (display === 'none' && $.trim($existingContent).length > 0 &&
-                        dfpOptions.collapseEmptyDivs === 'original') {
-                        $adUnit.show().html($existingContent);
-                        display = 'block display-original';
-                    }
+                        // if the div has been collapsed but there was existing content expand the
+                        // div and reinsert the existing content.
+                        var $existingContent = $adUnit.data('existingContent');
+                        if (display === 'none' && $.trim($existingContent).length > 0 &&
+                            dfpOptions.collapseEmptyDivs === 'original') {
+                            $adUnit.show().html($existingContent);
+                            display = 'block display-original';
+                        }
 
-                    $adUnit.removeClass('display-none').addClass('display-' + display);
+                        $adUnit.removeClass('display-none').addClass('display-' + display);
 
-                    // Excute afterEachAdLoaded callback if provided
-                    if (typeof dfpOptions.afterEachAdLoaded === 'function') {
-                        dfpOptions.afterEachAdLoaded.call(this, $adUnit, event);
-                    }
+                        // Excute afterEachAdLoaded callback if provided
+                        if (typeof dfpOptions.afterEachAdLoaded === 'function') {
+                            dfpOptions.afterEachAdLoaded.call(this, $adUnit, event);
+                        }
 
-                    // Excute afterAllAdsLoaded callback if provided
-                    if (typeof dfpOptions.afterAllAdsLoaded === 'function' && rendered === count) {
-                        dfpOptions.afterAllAdsLoaded.call(this, $adCollection);
-                    }
+                        // Excute afterAllAdsLoaded callback if provided
+                        if (typeof dfpOptions.afterAllAdsLoaded === 'function' && rendered === count) {
+                            dfpOptions.afterAllAdsLoaded.call(this, $adCollection);
+                        }
 
-                });
+                    });
+                    googletag.__dfp_event__ = true;
+                }
 
                 // this will work with AdblockPlus
                 if(dfpScript.shouldCheckForAdBlockers() && !googletag._adBlocked_) {

--- a/jquery.dfp.js
+++ b/jquery.dfp.js
@@ -343,8 +343,8 @@
                     setTimeout(function () {
                         var slots = pubadsService.getSlots ? pubadsService.getSlots() : [];
                         if (slots.length > 0) {
-                            $.get(slots[0].getContentUrl()).always(function (r) {
-                                if (r.status !== 200) {
+                            $.get({ url:slots[0].getContentUrl(), dataType: 'text' }).always(function (c, status) {
+                                if (status !== 'success') {
                                     $.each(slots, function () {
                                         var $adUnit = $('#' + this.getSlotId().getDomId());
                                         dfpOptions.afterAdBlocked.call(dfpScript, $adUnit, this);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "2.4.2",
     "devDependencies": {
         "grunt": "~0.4",
-        "grunt-contrib-jasmine": "^0.8.2",
+        "grunt-contrib-jasmine": "^1.1.0",
         "grunt-contrib-jshint": "^0.11.1",
         "grunt-contrib-uglify": "^0.8.0"
     },

--- a/tests/spec/loadingPhaseSpec.js
+++ b/tests/spec/loadingPhaseSpec.js
@@ -47,7 +47,7 @@ describe('Loading Phase', function () {
                 return false;
             }
         }, function () {
-            expect(window.googletag.getVersion()).toBeGreaterThan('23');
+            expect(window.googletag.getVersion()).toBeGreaterThan('109');
             done();
         }, 5000);
     });


### PR DESCRIPTION
This pull-request will:

- Prevent to register `slotRenderEnded` more then once
- fix bug #141, due to changes in DFP and different browser handling of the response
- fixed test and bumped dependencies